### PR TITLE
Update composer.json to support Kirby composer-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mzur/kirby-flash",
     "description": "Stores data in the session for the next request. Data is removed after the next page load.",
-    "type": "library",
+    "type": "kirby-plugin",
     "license": "MIT",
     "keywords": [
         "kirby",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,11 @@
     "description": "Stores data in the session for the next request. Data is removed after the next page load.",
     "type": "library",
     "license": "MIT",
-    "keywords": ["kirby", "flash", "session"],
+    "keywords": [
+        "kirby",
+        "flash",
+        "session"
+    ],
     "authors": [
         {
             "name": "Steve Jamesson",
@@ -30,9 +34,9 @@
     "require-dev": {
         "phpunit/phpunit": "^6.0",
         "mzur/kirby-defuse-session": "^1.0",
-        "getkirby/kirby": "^3.0"
+        "getkirby/cms": "^3.0"
     },
-    "extra": {
-        "kirby-cms-path": "vendor/getkirby/kirby"
+    "require": {
+        "getkirby/composer-installer": "^1.2"
     }
 }


### PR DESCRIPTION
The [Kirby plugin docs](https://getkirby.com/docs/guide/plugins/plugin-setup-basic#the-composer-json) now recommend using `getkirby/composer-installer` and `type: kirby-plugin` to ensure the plugin is set up in the expected Kirby path.

(Prior to this change, `kirby-flash` was not installed in the Kirby plugins directory, which broke my editor's PHP typing for it.)

The require-dev version of kirby should also be `getkirby/cms` instead of `getkirby/kirby`, since 3.0.

(Note: this issue also affects [mzur/kirby-uniform](https://github.com/mzur/kirby-uniform), but I saw you were vendoring dependencies and wasn't sure if you wanted to move to composer-required dependencies...)