### PR TITLE
Add feature to flash information for the current page load only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+kirby

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Allows you to "flash" data to the session, which will be available via the sessi
 
 Very useful for:
 
--   Saving submitted form data for form validation, specifically for the [Post/Redirect/Get](https://en.wikipedia.org/wiki/Post/Redirect/Get) design pattern
--   Displaying Success or Error messages after a page reload
+- Saving submitted form data for form validation, specifically for the [Post/Redirect/Get](https://en.wikipedia.org/wiki/Post/Redirect/Get) design pattern
+- Displaying Success or Error messages after a page reload
 
 ## Quick Example
 
@@ -21,8 +21,8 @@ Elsewhere...
 
 ```php
 <?php if (flash('thanks_message')): ?>
-    <?php echo flash('thanks_message'); ?>
-<?php endif; ?>
+    <?php echo flash('thanks_message') ?>
+<?php endif ?>
 ```
 
 ## Installation
@@ -39,7 +39,6 @@ composer require mzur/kirby-flash:^2.0
 ## Usage
 
 ### Set data
-
 ```php
 flash('key', 'value');
 
@@ -49,7 +48,6 @@ flash('username', 'jimihendrix');
 ```
 
 ### Get data
-
 ```php
 $value = flash('key');
 
@@ -60,7 +58,10 @@ $username = flash('username'); // "jimihendrix"
 ## Examples
 
 ```php
-flash('messages.errors', ['Email is required', 'Password is required']);
+flash('messages.errors', [
+    'Email is required',
+    'Password is required',
+]);
 
 flash('messages.errors'); // Array( 0 => 'Email is required', 1 => 'Password is required' )
 ```
@@ -70,9 +71,9 @@ flash('messages.errors'); // Array( 0 => 'Email is required', 1 => 'Password is 
 <div class="alert alert-error">
     <?php foreach (flash('messages.errors') as $message): ?>
         <div><?= html($message) ?></div>
-    <?php endforeach; ?>
+    <?php endforeach ?>
 </div>
-<?php endif; ?>
+<?php endif ?>
 ```
 
 ## `flash()` Helper Function
@@ -122,7 +123,7 @@ flash('message', 'Message for this response', true); // flash in a response to t
 
 By default Flash stores data under the session key `_flash`.
 
-So you _could_ access flash data like `$kirby->session()->get('_flash')` if you wanted to.
+So you *could* access flash data like `$kirby->session()->get('_flash')` if you wanted to.
 
 ### Changing the Session Key
 
@@ -137,6 +138,7 @@ Jevets\Kirby\Flash::setSessionKey('_my_custom_key');
 ```php
 Jevets\Kirby\Flash::sessionKey();
 ```
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -112,12 +112,11 @@ flash('messages.errors'); // Array( 0 => 'Email is required.', 1 => 'Phone is re
 Sometimes it can be useful to flash a message for the current page load, not the next one. This use case
 arises when a message should be shown in a response to the same request, rather than a redirect.
 
-The `flash()` helper method can be called with an optional **third parameter**, a boolean to toggle whether to flash _now_ instead of in the next page load. The default value of this parameter is `false`: `flash($key, $value = '', $now = false)`.
+The `flash()` helper method can be called with an optional third parameter, a boolean to toggle whether to keep the flashed variable only for the current request. The default value of this parameter is `false` which will keep the flashed variable for the next request.
 
 ```php
-flash('message', 'Message for redirect'); // flash on the next page load (default)
-flash('message', 'Message for this response', true); // flash in a response to the same request
-```
+flash('message', 'Message for redirect'); // Keep for next request
+flash('message', 'Message for this response', true); // Keep only for current request
 
 ## Session Key
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Allows you to "flash" data to the session, which will be available via the sessi
 
 Very useful for:
 
-- Saving submitted form data for form validation, specifically for the [Post/Redirect/Get](https://en.wikipedia.org/wiki/Post/Redirect/Get) design pattern
-- Displaying Success or Error messages after a page reload
+-   Saving submitted form data for form validation, specifically for the [Post/Redirect/Get](https://en.wikipedia.org/wiki/Post/Redirect/Get) design pattern
+-   Displaying Success or Error messages after a page reload
 
 ## Quick Example
 
@@ -21,8 +21,8 @@ Elsewhere...
 
 ```php
 <?php if (flash('thanks_message')): ?>
-    <?php echo flash('thanks_message') ?>
-<?php endif ?>
+    <?php echo flash('thanks_message'); ?>
+<?php endif; ?>
 ```
 
 ## Installation
@@ -39,6 +39,7 @@ composer require mzur/kirby-flash:^2.0
 ## Usage
 
 ### Set data
+
 ```php
 flash('key', 'value');
 
@@ -48,6 +49,7 @@ flash('username', 'jimihendrix');
 ```
 
 ### Get data
+
 ```php
 $value = flash('key');
 
@@ -58,10 +60,7 @@ $username = flash('username'); // "jimihendrix"
 ## Examples
 
 ```php
-flash('messages.errors', [
-    'Email is required',
-    'Password is required',
-]);
+flash('messages.errors', ['Email is required', 'Password is required']);
 
 flash('messages.errors'); // Array( 0 => 'Email is required', 1 => 'Password is required' )
 ```
@@ -71,9 +70,9 @@ flash('messages.errors'); // Array( 0 => 'Email is required', 1 => 'Password is 
 <div class="alert alert-error">
     <?php foreach (flash('messages.errors') as $message): ?>
         <div><?= html($message) ?></div>
-    <?php endforeach ?>
+    <?php endforeach; ?>
 </div>
-<?php endif ?>
+<?php endif; ?>
 ```
 
 ## `flash()` Helper Function
@@ -107,11 +106,23 @@ flash('messages.errors', ['Email is required.', 'Phone is required.']);
 flash('messages.errors'); // Array( 0 => 'Email is required.', 1 => 'Phone is required.' )
 ```
 
+## Flash for current page load only
+
+Sometimes it can be useful to flash a message for the current page load, not the next one. This use case
+arises when a message should be shown in a response to the same request, rather than a redirect.
+
+The `flash()` helper method can be called with an optional **third parameter**, a boolean to toggle whether to flash _now_ instead of in the next page load. The default value of this parameter is `false`: `flash($key, $value = '', $now = false)`.
+
+```php
+flash('message', 'Message for redirect'); // flash on the next page load (default)
+flash('message', 'Message for this response', true); // flash in a response to the same request
+```
+
 ## Session Key
 
 By default Flash stores data under the session key `_flash`.
 
-So you *could* access flash data like `$kirby->session()->get('_flash')` if you wanted to.
+So you _could_ access flash data like `$kirby->session()->get('_flash')` if you wanted to.
 
 ### Changing the Session Key
 
@@ -126,7 +137,6 @@ Jevets\Kirby\Flash::setSessionKey('_my_custom_key');
 ```php
 Jevets\Kirby\Flash::sessionKey();
 ```
-
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "mzur/kirby-defuse-session": "^1.0",
-        "getkirby/kirby": "^3.0"
+        "getkirby/cms": "^3.0"
     },
     "extra": {
         "kirby-cms-path": "vendor/getkirby/kirby"

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,9 @@
 {
     "name": "mzur/kirby-flash",
     "description": "Stores data in the session for the next request. Data is removed after the next page load.",
-    "type": "kirby-plugin",
+    "type": "library",
     "license": "MIT",
-    "keywords": [
-        "kirby",
-        "flash",
-        "session"
-    ],
+    "keywords": ["kirby", "flash", "session"],
     "authors": [
         {
             "name": "Steve Jamesson",
@@ -34,9 +30,9 @@
     "require-dev": {
         "phpunit/phpunit": "^6.0",
         "mzur/kirby-defuse-session": "^1.0",
-        "getkirby/cms": "^3.0"
+        "getkirby/kirby": "^3.0"
     },
-    "require": {
-        "getkirby/composer-installer": "^1.2"
+    "extra": {
+        "kirby-cms-path": "vendor/getkirby/kirby"
     }
 }

--- a/src/Flash.php
+++ b/src/Flash.php
@@ -62,7 +62,7 @@ class Flash
      */
     public static function sessionKey()
     {
-        return static::$instance->getSessionKey();
+        return static::getInstance()->getSessionKey();
     }
 
     /**

--- a/src/Flash.php
+++ b/src/Flash.php
@@ -25,7 +25,7 @@ class Flash
      *
      * @var array
      */
-    protected $data;
+    protected $initialData;
 
     /**
      * Get a new instance
@@ -36,7 +36,9 @@ class Flash
     public function __construct($sessionKey)
     {
         $this->sessionKey = $sessionKey;
-        $this->data = App::instance()->session()->pull($this->sessionKey, []);
+        $this->initialData = App::instance()
+            ->session()
+            ->pull($this->sessionKey, []);
     }
 
     /**
@@ -93,8 +95,14 @@ class Flash
      */
     public function set($key, $value)
     {
-        $this->data[$key] = $value;
-        App::instance()->session()->set($this->sessionKey, $this->data);
+        $this->initialData[$key] = $value;
+        $nextData = App::instance()
+            ->session()
+            ->get($this->sessionKey, []);
+        $nextData[$key] = $value;
+        App::instance()
+            ->session()
+            ->set($this->sessionKey, $nextData);
     }
 
     /**
@@ -106,7 +114,9 @@ class Flash
      */
     public function get($key, $default = null)
     {
-        return isset($this->data[$key]) ? $this->data[$key] : $default;
+        return isset($this->initialData[$key])
+            ? $this->initialData[$key]
+            : $default;
     }
 
     /**
@@ -116,6 +126,6 @@ class Flash
      */
     public function all()
     {
-        return $this->data;
+        return $this->initialData;
     }
 }

--- a/src/Flash.php
+++ b/src/Flash.php
@@ -25,7 +25,7 @@ class Flash
      *
      * @var array
      */
-    protected $initialData;
+    protected $data;
 
     /**
      * Get a new instance
@@ -36,7 +36,7 @@ class Flash
     public function __construct($sessionKey)
     {
         $this->sessionKey = $sessionKey;
-        $this->initialData = App::instance()
+        $this->data = App::instance()
             ->session()
             ->pull($this->sessionKey, []);
     }
@@ -96,7 +96,7 @@ class Flash
      */
     public function set($key, $value, $now = false)
     {
-        $this->initialData[$key] = $value;
+        $this->data[$key] = $value;
         if ($now === false) {
             $nextData = App::instance()
                 ->session()
@@ -117,8 +117,8 @@ class Flash
      */
     public function get($key, $default = null)
     {
-        return isset($this->initialData[$key])
-            ? $this->initialData[$key]
+        return isset($this->data[$key])
+            ? $this->data[$key]
             : $default;
     }
 
@@ -129,6 +129,6 @@ class Flash
      */
     public function all()
     {
-        return $this->initialData;
+        return $this->data;
     }
 }

--- a/src/Flash.php
+++ b/src/Flash.php
@@ -91,18 +91,21 @@ class Flash
      *
      * @param  string  $key
      * @param  mixed  $value
+     * @param  mixed  optional set $value for current page load only
      * @return void
      */
-    public function set($key, $value)
+    public function set($key, $value, $now = false)
     {
         $this->initialData[$key] = $value;
-        $nextData = App::instance()
-            ->session()
-            ->get($this->sessionKey, []);
-        $nextData[$key] = $value;
-        App::instance()
-            ->session()
-            ->set($this->sessionKey, $nextData);
+        if ($now === false) {
+            $nextData = App::instance()
+                ->session()
+                ->get($this->sessionKey, []);
+            $nextData[$key] = $value;
+            App::instance()
+                ->session()
+                ->set($this->sessionKey, $nextData);
+        }
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -12,13 +12,14 @@ if (!function_exists('flash')) {
      *
      * @param string $key
      * @param mixed optional $value to set
+     * @param mixed optional set $value for current page load only
      */
-    function flash($key, $setValue = '')
+    function flash($key, $setValue = '', $now = false)
     {
         $flash = Flash::getInstance();
 
         if ($setValue) {
-            $flash->set($key, $setValue);
+            $flash->set($key, $setValue, $now);
             return $setValue;
         } else {
             return $flash->get($key);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -12,7 +12,7 @@ if (!function_exists('flash')) {
      *
      * @param string $key
      * @param mixed optional $value to set
-     * @param mixed optional set $value for current page load only
+     * @param boolean optional set $value for current page load only
      */
     function flash($key, $setValue = '', $now = false)
     {

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -14,13 +14,11 @@ class FlashTest extends TestCase
 
     public function testSessionKey()
     {
-        $flash = Flash::getInstance();
         $this->assertEquals('_flash', Flash::sessionKey());
     }
 
     public function testSetSessionKey()
     {
-        $flash = Flash::getInstance();
         Flash::setSessionKey('_myflash');
         $this->assertEquals('_myflash', Flash::sessionKey());
     }

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -61,4 +61,17 @@ class FlashTest extends TestCase
         $flash = Flash::getInstance();
         $this->assertNull($flash->get('key'));
     }
+
+    public function testOverlappingSessions()
+    {
+        $flash = Flash::getInstance();
+        $flash->set("key", "value");
+        $this->nextPageLoad();
+        $flash = Flash::getInstance();
+        $this->assertEquals("value", $flash->get("key"));
+        $flash->set("key2", "value2");
+        $this->nextPageLoad();
+        $flash = Flash::getInstance();
+        $this->assertNull($flash->get("key"));
+    }
 }

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -65,13 +65,23 @@ class FlashTest extends TestCase
     public function testOverlappingSessions()
     {
         $flash = Flash::getInstance();
-        $flash->set("key", "value");
+        $flash->set('key', 'value');
         $this->nextPageLoad();
         $flash = Flash::getInstance();
-        $this->assertEquals("value", $flash->get("key"));
-        $flash->set("key2", "value2");
+        $this->assertEquals('value', $flash->get('key'));
+        $flash->set('key2', 'value2');
         $this->nextPageLoad();
         $flash = Flash::getInstance();
-        $this->assertNull($flash->get("key"));
+        $this->assertNull($flash->get('key'));
+    }
+
+    public function testNow()
+    {
+        $flash = Flash::getInstance();
+        $flash->set('key', 'value', true);
+        $this->assertEquals('value', $flash->get('key'));
+        $this->nextPageLoad();
+        $flash = Flash::getInstance();
+        $this->assertNull($flash->get('key'));
     }
 }

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -6,7 +6,6 @@ use Jevets\Kirby\Flash;
 
 class FlashTest extends TestCase
 {
-
     public function testGetInstance()
     {
         $flash = Flash::getInstance();
@@ -15,11 +14,13 @@ class FlashTest extends TestCase
 
     public function testSessionKey()
     {
+        $flash = Flash::getInstance();
         $this->assertEquals('_flash', Flash::sessionKey());
     }
 
     public function testSetSessionKey()
     {
+        $flash = Flash::getInstance();
         Flash::setSessionKey('_myflash');
         $this->assertEquals('_myflash', Flash::sessionKey());
     }
@@ -47,5 +48,17 @@ class FlashTest extends TestCase
         $this->assertEquals('value', $flash->get('key'));
         $this->assertEquals('value2', $flash2->get('key'));
         $this->assertEquals('value3', $flash3->get('key'));
+    }
+
+    public function testNextSession()
+    {
+        $flash = Flash::getInstance();
+        $flash->set('key', 'value');
+        $this->nextPageLoad();
+        $flash = Flash::getInstance();
+        $this->assertEquals('value', $flash->get('key'));
+        $this->nextPageLoad();
+        $flash = Flash::getInstance();
+        $this->assertNull($flash->get('key'));
     }
 }

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -71,6 +71,7 @@ class FlashTest extends TestCase
         $this->nextPageLoad();
         $flash = Flash::getInstance();
         $this->assertNull($flash->get('key'));
+        $this->assertEquals('value2', $flash->get('key2'));
     }
 
     public function testNow()

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -8,7 +8,6 @@ class HelperTest extends TestCase
     {
         $this->assertTrue(function_exists('flash'));
     }
-
     public function testFlash()
     {
         flash('mykey', 'myvalue');

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -13,6 +13,14 @@ class HelperTest extends TestCase
         flash('mykey', 'myvalue');
         $this->assertEquals('myvalue', flash('mykey'));
         flash('mykey', 'myvalue2');
+        $this->nextPageLoad();
         $this->assertEquals('myvalue2', flash('mykey'));
+    }
+    public function testFlashNow()
+    {
+        flash('mykey', 'myvalue', true);
+        $this->assertEquals('myvalue', flash('mykey'));
+        $this->nextPageLoad();
+        $this->assertNull(flash('mykey'));
     }
 }

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -8,6 +8,7 @@ class HelperTest extends TestCase
     {
         $this->assertTrue(function_exists('flash'));
     }
+
     public function testFlash()
     {
         flash('mykey', 'myvalue');
@@ -16,6 +17,7 @@ class HelperTest extends TestCase
         $this->nextPageLoad();
         $this->assertEquals('myvalue2', flash('mykey'));
     }
+
     public function testFlashNow()
     {
         flash('mykey', 'myvalue', true);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,15 +3,31 @@
 namespace Jevets\Kirby\Flash\Tests;
 
 use Mzur\Kirby\DefuseSession\Defuse;
+use Jevets\Kirby\Flash;
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * Default preparation for each test.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Defuse::defuse();
+        $this->nextPageLoad();
+        // run two full page loads to ensure each test is isolated
+        $this->nextPageLoad();
+    }
+
+    /**
+     * Clears the stored static Flash instance, simulating a new page load
+     */
+    public function nextPageLoad()
+    {
+        $destroyInstance = function () {
+            static::$instance = null;
+        };
+        $destroyInstance = $destroyInstance->bindTo(null, Flash::class);
+        $destroyInstance();
     }
 }


### PR DESCRIPTION
Sometimes it can be useful to flash a message for the current page load, not the next one. This use case arises when a message should be shown in a response to the same request, rather than a redirect.

I extended the helper and `set` with the following signature: `set($key, $value = '', $now = false)`. Under the hood, this essentially just skips setting the value to the Kirby session.

---

In the process of adding this feature, I also added tests to test the behavior of subsequent page loads. I did this by creating a test helper method called `nextPageLoad` which clears the Flash static `$instance` property.

These new tests revealed an existing bug: setting any new flash data carried all messages for the current page load over to the next one. I fixed this bug, but the corrected behavior might technically be considered a breaking change.